### PR TITLE
Add search.h include file for complete compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,10 @@ target_include_directories(naive-tsearch PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/${PROJECT_NAME}")
 set(NAIVE_TSEARCH_PUBLIC_HEADERS
+    search.h
     tsearch.h
     tsearch.h.inc)
 set_target_properties(naive-tsearch PROPERTIES
-#    PUBLIC_HEADER "${NAIVE_TSEARCH_PUBLIC_HEADERS}"
     C_STANDARD 99
     C_EXTENSIONS OFF)
 target_compile_options(naive-tsearch PRIVATE
@@ -38,12 +38,12 @@ add_library(naive-tsearch::naive-tsearch-hdronly ALIAS naive-tsearch-hdronly)
 target_include_directories(naive-tsearch-hdronly INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/${PROJECT_NAME}")
+target_compile_definitions(naive-tsearch-hdronly INTERFACE
+    NAIVE_TSEARCH_HDRONLY)
 set(NAIVE_TSEARCH_HDRONLY_PUBLIC_HEADERS
     tsearch_hdronly.h
     tsearch.c.inc
     tsearch.h.inc)
-#set_target_properties(naive-tsearch-hdronly PROPERTIES
-#        PUBLIC_HEADER "${NAIVE_TSEARCH_HDRONLY_PUBLIC_HEADERS}")
 
 option(NAIVE_TSEARCH_TESTS "Build ${PROJECT_NAME} tests + enable CTest" "${NAIVE_TSEARCH_MAIN_PROJECT}")
 if(NAIVE_TSEARCH_TESTS)
@@ -59,24 +59,19 @@ if(NAIVE_TSEARCH_INSTALL)
 
     configure_file(naive-tsearch.pc.in naive-tsearch.pc @ONLY)
 
-    option(NAIVE_TSEARCH_INSTALL_LIB "Install ${PROJECT_NAME} library" ON)
-    if(NAIVE_TSEARCH_INSTALL_LIB)
-        install(TARGETS naive-tsearch EXPORT naive-tsearchTargets
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-        install(FILES ${NAIVE_TSEARCH_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
-    endif()
-    option(NAIVE_TSEARCH_INSTALL_HDRONLY "Install ${PROJECT_NAME} header-only" ON)
-    if(NAIVE_TSEARCH_INSTALL_HDRONLY)
-        install(TARGETS naive-tsearch-hdronly EXPORT naive-tsearchTargets
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-        install(FILES ${NAIVE_TSEARCH_HDRONLY_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
-    endif()
+    install(TARGETS naive-tsearch EXPORT naive-tsearchTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES ${NAIVE_TSEARCH_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+
+    install(TARGETS naive-tsearch-hdronly EXPORT naive-tsearchTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES ${NAIVE_TSEARCH_HDRONLY_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 
     install(EXPORT naive-tsearchTargets
         FILE naive-tsearchConfig.cmake

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,11 +10,11 @@ class NaiveTsearchConan(ConanFile):
     homepage = "https://github.com/kulp/naive-tsearch"
     url = "https://github.com/kulp/naive-tsearch"
     license = "MIT"
-    exports_sources = "CMakeLists.txt", "README.md", "*.c", "*.h", "*.in", "*.inc", "LICENSE"
+    exports_sources = "CMakeLists.txt", "README.md", "*.c", "*.h", "*.in", "*.inc", "LICENSE", "tests/**"
     exports = "LICENSE"
     no_copy_source = True
     settings = "os", "arch", "compiler", "build_type"
-    requires = "boost/1.72.0"
+    requires = "boost/1.73.0"
     generators = "cmake"
 
     def set_version(self):

--- a/search.h
+++ b/search.h
@@ -1,0 +1,10 @@
+#ifndef NAIVE_TSEARCH_SEARCH_H_
+#define NAIVE_TSEARCH_SEARCH_H_
+
+#if defined(NAIVE_TSEARCH_HDRONLY)
+# include "tsearch_hdronly.h"
+#else
+# include "tsearch.h"
+#endif
+
+#endif // NAIVE_TSEARCH_SEARCH_H_

--- a/tests/test_tsearch.hpp
+++ b/tests/test_tsearch.hpp
@@ -7,6 +7,9 @@
 #include "tsearch_hdronly.h"
 #elif defined(TEST_SYSTEM_TSEARCH)
 #include <search.h>
+#if defined(NAIVE_TSEARCH_SEARCH_H_)
+#error "Did not include system tsearch library!"
+#endif
 #else
 #error "Don't know what tsearch implementation to test"
 #endif

--- a/tsearch.h
+++ b/tsearch.h
@@ -1,5 +1,5 @@
-#ifndef TSEARCH_H_
-#define TSEARCH_H_
+#ifndef NAIVE_TSEARCH_H_
+#define NAIVE_TSEARCH_H_
 
 #if defined(__cplusplus)
 extern "C" {
@@ -13,4 +13,4 @@ extern "C" {
 }
 #endif
 
-#endif // TSEARCH_H_
+#endif // NAIVE_TSEARCH_H_

--- a/tsearch_hdronly.h
+++ b/tsearch_hdronly.h
@@ -1,9 +1,9 @@
-#ifndef TSEARCH_HDRONLY_H_
-#define TSEARCH_HDRONLY_H_
+#ifndef NAIVE_TSEARCH_HDRONLY_H_
+#define NAIVE_TSEARCH_HDRONLY_H_
 
 #define NAIVE_TSEARCH_PREFIX
 #define NAIVE_TSEARCH_API static
 #include "tsearch.h.inc"
 #include "tsearch.c.inc"
 
-#endif // TSEARCH_HDRONLY_H_
+#endif // NAIVE_TSEARCH_HDRONLY_H_


### PR DESCRIPTION
Add a `search.h` header that will include the `tsearch.h` or `tsearch_hdronly.h`, depending on the macro `NAIVE_TSEARCH_HDRONLY`.
This allows to use this library as a drop-in replacement of glibc's tsearch.
