### PR TITLE
Test across a broader matrix of CI configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 language: cpp
 
-jobs:
-  include:
-  - os: linux
-    dist: bionic
-    compiler: gcc
-  - os: linux
-    dist: bionic
-    compiler: clang
-  - os: osx
-    compiler: clang
-    osx_image: xcode11.3
+dist: bionic
+
+osx_image: xcode11.3
+
+os:
+  - linux
+  - osx
+
+arch:
+  - amd64
+  - arm64
+  - ppc64le
+  - s390x
+
+compiler:
+  - gcc
+  - clang
 
 before_install:
   - .ci/install.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(NAIVE_TSEARCH_MAIN_PROJECT OFF)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -9,8 +9,10 @@ file(READ "NAIVETSEARCH_VERSION" VERSION)
 string(STRIP "${VERSION}" VERSION)
 
 project(naive-tsearch VERSION "${VERSION}" LANGUAGES C
-    HOMEPAGE_URL "https://github.com/kulp/naive-tsearch"
     DESCRIPTION "A simple tsearch() implementation for platforms without one")
+
+# Using HOMEPAGE_URL in `project` requires CMake >=3.12
+set(PROJECT_HOMEPAGE_URL "https://github.com/kulp/naive-tsearch")
 
 if(MSVC)
     # Remove warning flags to avoid `cl : Command line warning D9025 : overriding '/W3' with '/W4'` warning


### PR DESCRIPTION
Travis lets us build on several OSes and architectures. Taking advantage of that fact can expose issues more quickly.

Building the whole matrix is not really necessary, but since each individual job takes only about a minute, having ten jobs is not a burden at this time.

Eventually we could also try to test on [Windows with Travis](https://docs.travis-ci.com/user/reference/windows/) as well, but AppVeyor is already set up for Windows builds (thanks, @madebr), so the only major reason to do this would be to consolidate CI configuration and see CI results in one place.