### PR TITLE
Create reproducible .tar.gz release tarball + documentation fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+tab_width = 4
+insert_final_newline = true
+charset = utf-8
+
+[*.yml]
+indent_size = 2

--- a/Changelog
+++ b/Changelog
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (nothing)
 
 ### Changed
-
-(nothing)
+- Make .tar.gz release tarballs reproducible by zero'ing the time stamp
 
 ### Removed
 

--- a/create_source_tarball.py
+++ b/create_source_tarball.py
@@ -31,8 +31,6 @@ for tar_compression in tar_compressions:
 
 
 # Zero the embedded timestamp in the gzip'ed tarball
-targz = Path("naive-tsearch-{}.tar.gz".format(version))
-if targz.is_file():
-    with targz.open("r+b") as f:
-        f.seek(4, 0)
-        f.write(b"\x00\x00\x00\x00")
+with open("naive-tsearch-{}.tar.gz".format(version), "r+b") as f:
+    f.seek(4, 0)
+    f.write(b"\x00\x00\x00\x00")

--- a/create_source_tarball.py
+++ b/create_source_tarball.py
@@ -28,3 +28,11 @@ for tar_compression in tar_compressions:
             name = Path(tar_filebasename) / file.relative_to(WORKPATH)
             print("Adding {}...".format(name))
             tar.add(name=file, arcname=str(name))
+
+
+# Zero the embedded timestamp in the gzip'ed tarball
+targz = Path("naive-tsearch-{}.tar.gz".format(version))
+if targz.is_file():
+    with targz.open("r+b") as f:
+        f.seek(4, 0)
+        f.write(b"\x00\x00\x00\x00")

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,5 +1,6 @@
 # Release checklist
 Lists of steps one should perform prior to creating a new release.
+In total 2 commits should be made: one for the release, and one for the post-release.
 
 1. Remove all `build*` subdirectories
 2. Make sure you're on the current master and that the tree is in pristine condition using `git status`.
@@ -7,16 +8,19 @@ Run `git reset --hard HEAD` and `git clean -x -f` when unsure.
 3. Bump the version in `NAIVETSEARCH_VERSION` (found in the root directory) and rename the `[Unreleased]` section of the `Changelog` to the version used in `NAIVETSEARCH_VERSION`. Use the format `[x.y.z] - YYY-MM-DD` as name for the new release section.
   Keep empty added/changed/removed subsections.
   Read [keep a changelog](https://keepachangelog.com/) for the conventions.
+  **Don't commit yet.**
 4. Run the following commands to test the repository:
     ```
+    rm -rf build_cmake
     mkdir build_cmake && cd build_cmake
     cmake ..
-    cmake --build ..
+    cmake --build .
     ctest .
     cd ..
+    rm -rf build_conan
     mkdir build_conan && cd build_conan
-    python -m conans.main install ..
-    python -m conans.main build ..
+    python -m conans.conan install ..
+    python -m conans.conan build ..
     ctest .
     cd ..
     ```


### PR DESCRIPTION
- Documentation fixes
- Make .tar.gz reproducible
- Add `.editorconfig` for autoconfiguring IDE's (https://editorconfig.org/)

Fixes #11